### PR TITLE
Convert detail field on BuildError and BuildWarning to OptionalField

### DIFF
--- a/Sources/XCMetricsBackendLib/Builds/Controllers/BuildController.swift
+++ b/Sources/XCMetricsBackendLib/Builds/Controllers/BuildController.swift
@@ -326,8 +326,24 @@ public struct BuildController: RouteCollection {
         guard let buildId = req.parameters.get("id") else {
             throw Abort(.badRequest)
         }
+        // omitting `detail` field which makes the payload smaller and reduces duplicate data
         return BuildError.query(on: req.db)
                 .filter(\.$buildIdentifier == buildId)
+                .field(\.$characterRangeEnd)
+                .field(\.$documentURL)
+                .field(\.$endingColumn)
+                .field(\.$id)
+                .field(\.$parentIdentifier)
+                .field(\.$day)
+                .field(\.$type)
+                .field(\.$title)
+                .field(\.$endingLine)
+                .field(\.$startingLine)
+                .field(\.$parentType)
+                .field(\.$startingColumn)
+                .field(\.$buildIdentifier)
+                .field(\.$characterRangeStart)
+                .field(\.$severity)
                 .all()
     }
 
@@ -367,8 +383,25 @@ public struct BuildController: RouteCollection {
         guard let buildId = req.parameters.get("id") else {
             throw Abort(.badRequest)
         }
+        // omitting `detail` field which makes the payload smaller and reduces duplicate data
         return BuildWarning.query(on: req.db)
                 .filter(\.$buildIdentifier == buildId)
+                .field(\.$characterRangeEnd)
+                .field(\.$documentURL)
+                .field(\.$endingColumn)
+                .field(\.$id)
+                .field(\.$parentIdentifier)
+                .field(\.$day)
+                .field(\.$type)
+                .field(\.$title)
+                .field(\.$endingLine)
+                .field(\.$startingLine)
+                .field(\.$parentType)
+                .field(\.$clangFlag)
+                .field(\.$startingColumn)
+                .field(\.$buildIdentifier)
+                .field(\.$characterRangeStart)
+                .field(\.$severity)
                 .all()
     }
 

--- a/Sources/XCMetricsBackendLib/Common/Models/BuildError.swift
+++ b/Sources/XCMetricsBackendLib/Common/Models/BuildError.swift
@@ -69,7 +69,7 @@ public final class BuildError: Model, Content, PartitionedByDay {
     @Field(key: "character_range_end")
     var characterRangeEnd: Int32
 
-    @Field(key: "detail")
+    @OptionalField(key: "detail")
     var detail: String?
 
     @Field(key: "day")

--- a/Sources/XCMetricsBackendLib/Common/Models/BuildWarning.swift
+++ b/Sources/XCMetricsBackendLib/Common/Models/BuildWarning.swift
@@ -72,7 +72,7 @@ public final class BuildWarning: Model, Content, PartitionedByDay {
     @Field(key: "character_range_end")
     var characterRangeEnd: Int32
 
-    @Field(key: "detail")
+    @OptionalField(key: "detail")
     var detail: String?
 
     @Field(key: "day")


### PR DESCRIPTION
When querying a build with 100 warnings, the query would completely time out. Upon further investigation, exporting the data revealed that the entire payload was 230MB for 100 warnings which seemed really high. Also, the `detail` column in the BuildErrors and BuildWarnings tables is just a composition of the individual elements that make up the entity.

### Affected Areas:
- `v1/build/warning/<buildId>` endpoint can throw a 503
- `v1/build/error/<buildId>` endpoint can throw a 503
- Backstage UI plugin viewing warnings on a build

### Proposed Changes:
- set `detail` field as `@OptionalField`
- omit `detail` field from response payload
- `detail` returns `null` value

### Steps to Reproduce:

1. Log into xcmetrics postgres instance
2. run the query  `select * from public.build_warnings WHERE build_identifier = <someId> LIMIT 100;`
3. Analyze query time
4. run the query - `select build_identifier, document_url, severity, type, title, day, clang_flag, starting_line, ending_line, starting_column, ending_column, character_range_start, character_range_end from public.build_warnings WHERE build_identifier = <someId> LIMIT 100;`
5. Compare faster query time