### PR TITLE
[DO-2957] Remove quotes and spaces from machine name to avoid Postres escaping issues

### DIFF
--- a/Sources/XCMetricsClient/Machine Name Reader/MachineNameReader.swift
+++ b/Sources/XCMetricsClient/Machine Name Reader/MachineNameReader.swift
@@ -37,6 +37,48 @@ class HashedMacOSMachineNameReader: MachineNameReader {
         if encrypted {
             return Host.current().localizedName?.md5()
         }
-        return Host.current().localizedName
+        return removeLocalizedSingleQuotesAndSpaces(Host.current().localizedName)
+    }
+
+    func removeLocalizedSingleQuotesAndSpaces(from input: String) -> String {
+        print("testing this")
+        var sanitizedString = input
+
+        // Define a set of localized variations of single quotes
+        let localizedSingleQuotes: Set<Character> = [
+            "‘", "’", "`", "ʹ", "′", "‛", "❛", "❜", "＇"
+        ]
+
+        // Iterate through each character in the input string
+        for char in input {
+            // Check if the character is a localized variation of a single quote or space
+            if localizedSingleQuotes.contains(char) || char.isWhitespace {
+                // Remove the localized variation from the string
+                sanitizedString.removeAll { $0 == char }
+            }
+        }
+
+        return sanitizedString
     }
 }
+
+
+// import XCTest
+
+// class StringSanitizationTests: XCTestCase {
+
+//     func testRemoveLocalizedSingleQuotesAndSpaces() {
+//         // Given
+//         let inputString = "This is a ‘string’ with ’localized’ variations of `single quotes’."
+        
+//         // When
+//         let sanitized = removeLocalizedSingleQuotesAndSpaces(from: inputString)
+        
+//         // Then
+//         XCTAssertEqual(sanitized, "Thisisastringwithlocalizedvariationsofsinglequotes.")
+//     }
+    
+// }
+
+// // Run the tests
+// StringSanitizationTests.defaultTestSuite.run()

--- a/Sources/XCMetricsClient/Machine Name Reader/MachineNameReader.swift
+++ b/Sources/XCMetricsClient/Machine Name Reader/MachineNameReader.swift
@@ -37,28 +37,17 @@ class HashedMacOSMachineNameReader: MachineNameReader {
         if encrypted {
             return Host.current().localizedName?.md5()
         }
-        return removeLocalizedSingleQuotesAndSpaces(Host.current().localizedName)
+        return removeLocalizedSingleQuotesAndSpaces(from: Host.current().localizedName)
     }
 
     func removeLocalizedSingleQuotesAndSpaces(from input: String) -> String {
-        print("testing this")
-        var sanitizedString = input
-
         // Define a set of localized variations of single quotes
         let localizedSingleQuotes: Set<Character> = [
-            "‘", "’", "`", "ʹ", "′", "‛", "❛", "❜", "＇"
+            "‘", "’", "`", "ʹ", "′", "‛", "❛", "❜", "＇", "'"
         ]
 
         // Iterate through each character in the input string
-        for char in input {
-            // Check if the character is a localized variation of a single quote or space
-            if localizedSingleQuotes.contains(char) || char.isWhitespace {
-                // Remove the localized variation from the string
-                sanitizedString.removeAll { $0 == char }
-            }
-        }
-
-        return sanitizedString
+        return input.filter { !localizedSingleQuotes.contains($0) && !$0.isWhitespace }
     }
 }
 


### PR DESCRIPTION
XCMetrics creates a unique identifier by concatenating the users hostname with a UUID. The problem is the user can have different apostrophe characters and Postgresql is particular around escaping single quote strings. Example:

`Louie's MacbookPro` (encoded: %27)

`Louie’s Macbook Pro` (encoded: %E2%80%99)

These will both look like this as an ID in postgres

`"id":Louie’s MacBook Pro_E985CCF2-2132-4F13-B7E3-F0CD15A78C49_1`

The quote can seem innocent but the error that is thrown is:

server: syntax error at or near "s" (scanner_yyerror) [request-id: 5119B344-B3D1-4949-A271-0B2AB0AC84CB]

scanner_yyerrors:

[Getting 'error: syntax error at or near...' in Postgresql insert query](https://stackoverflow.com/questions/69607231/getting-error-syntax-error-at-or-near-in-postgresql-insert-query) 

[Single quote in message results in error "scanner_yyerror" · Issue #1 · socketio/socket.io-postgres-emitter](https://github.com/socketio/socket.io-postgres-emitter/issues/1) 

 Upgrading the swift PG driver could fix it, but it’s probably best to have a identifier without spaces or ' because you have to URL encode them when using the API

---
I couldn't get my system host to add apostrophe or spaces, it removed them once I went into:

`Settings -> General -> About -> Name`

Deploying to edge so we can test on dev aws environment.