### PR TITLE
[DO-2957] Revert set allowed characters for hostname

### DIFF
--- a/Sources/XCMetricsClient/Machine Name Reader/MachineNameReader.swift
+++ b/Sources/XCMetricsClient/Machine Name Reader/MachineNameReader.swift
@@ -37,32 +37,6 @@ class HashedMacOSMachineNameReader: MachineNameReader {
         if encrypted {
             return Host.current().localizedName?.md5()
         }
-        return normalizing(Host.current().localizedName)
-    }
-
-    private func normalizing(_ input: String) -> String {
-        let allowedChars = Set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
-        return String(input.filter { allowedChars.contains($0) })
+        return Host.current().localizedName
     }
 }
-
-
-// import XCTest
-
-// class StringSanitizationTests: XCTestCase {
-
-//     func testRemoveLocalizedSingleQuotesAndSpaces() {
-//         // Given
-//         let inputString = "This is a ‘string’ with ’localized’ variations of `single quotes’."
-        
-//         // When
-//         let sanitized = removeLocalizedSingleQuotesAndSpaces(from: inputString)
-        
-//         // Then
-//         XCTAssertEqual(sanitized, "Thisisastringwithlocalizedvariationsofsinglequotes.")
-//     }
-    
-// }
-
-// // Run the tests
-// StringSanitizationTests.defaultTestSuite.run()


### PR DESCRIPTION
Reverting this change to match edge.

Hostname I think comes from XCLogParser which is on the users device. I think the workaround is set the env var:

XCMETRICS_REDACT_USER_DATA to "1"

We don't really need the users hostname, we just need the CPU/GPU specs and times which should be good.